### PR TITLE
Add WriteActivityRecordRole as SSM param to use in encryption backup key policy

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -104,3 +104,12 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}-BackupWrapperKey"
       TargetKeyId: !GetAtt BackupWrapperKey.Arn
+
+  AccountManagementBackendWriteActivityLogRoleSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: "Root ARN of the acctount-management-backend AWS account"
+      Name: !Sub "/${AWS::StackName}/${Environment}/AccountManagement/Backend/WriteActivityRecordRole"
+      Type: String
+      Value: "arn:aws:iam::<fill-in-account-id>:role/account-mgmt-backend-WriteActivityRecordRole-<fill-in-account-id>"
+      


### PR DESCRIPTION
the ARN of WriteActivityRecordRole needs to be added as a ssm param before it can be used in the KeyPolicy for the backup wrapper key. 

This templates out a placeholder value in each environment which we will need to manually update with the actual value once deployed.

Documentation which i have followed here on how to allow a different AWS account access a KMS key:
https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html#cross-account-key-policy