### PR TITLE
PSREDEV-1203: added demo as an allowed value

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -23,6 +23,7 @@ Parameters:
     Description: The name of the environment to deploy to (provided by the pipeline)
     Type: String
     AllowedValues:
+      - demo
       - dev
       - build
       - staging


### PR DESCRIPTION
Similar to the stubs template, we need to make this template.yaml 'demo' compatible by adding that as an allowed value in the parameters.