### PR TITLE
BAU: Fix the deploy to dev action

### DIFF
--- a/.github/workflows/publish-to-dev.yaml
+++ b/.github/workflows/publish-to-dev.yaml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/lint-cloudformation.yaml
     secrets: inherit
     with:
-      gitRef: ${{ inputs.gitRef || main }}
+      gitRef: ${{ inputs.gitRef || 'main' }}
 
   deploy_to_dev:
     permissions:


### PR DESCRIPTION
We need to wrap the string value in single quotes when using it in an expression. 

I've tested this works by running the action against this branch - see https://github.com/govuk-one-login/di-account-data-backend/actions/runs/13929225983 