### PR TITLE
BAU: Remove Node install steps from Actions

### DIFF
--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -47,14 +47,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Install ESbuild
-        run: npm install -g esbuild@0.15.12
-
       - name: Set up Python 3.9
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:

--- a/.github/workflows/publish-to-dev.yaml
+++ b/.github/workflows/publish-to-dev.yaml
@@ -47,14 +47,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Install ESbuild
-        run: npm install -g esbuild@0.15.12
-
       - name: Set up Python 3.9
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:

--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -25,11 +25,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version-file: ".nvmrc"
-
       - name: Set up Python 3.9
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:


### PR DESCRIPTION
We removed all the Lambda code from this repo in #16 - it wasn't used and we were getting security warnings.
In that we missed that the actions also install Node and rely on a now deleted file. Thankfully we can just also delete the affected steps from the action definitions as well.